### PR TITLE
Isolate ddx temporary to eliminate ADMS second derivatives

### DIFF
--- a/code/ekv3_include/ekv3_oppoints.va
+++ b/code/ekv3_include/ekv3_oppoints.va
@@ -104,10 +104,22 @@ begin : OPinfo
     Cgdov = M *( abs(ddx((QDOV),V(`GEFF))));
 
     ///Total extrinsic capacitance////////////
-    tmp1 = M * abs(ddx(QSFR,V(`GEFF)));
-    tmp2 = M * abs(ddx(QDFR,V(`GEFF)));
-    Cgsex = Cgsi + (CGSO * M * WeffNF) + Cgsov + tmp1;
-    Cgdex = Cgdi + (CGDO * M * WeffNF) + Cgdov + tmp2;
+
+    // MODIFIED BY T.V. Russo, 2025-01-20
+    // The four code lines below have been wrapped in a begin/end block
+    // and tmp1 and tmp2 made block local variables here.  This is simply to
+    // stop Xyce/ADMS from being confused by the ddx into thinking it needs
+    // to generate second derivative any time the global tmp1 and tmp2
+    // variables are used in an expression that will ultimately be used in a
+    // contribution.
+    //    c.f https://github.com/Xyce/Xyce/issues/104
+    begin
+      real tmp1,tmp2;
+      tmp1 = M * abs(ddx(QSFR,V(`GEFF)));
+      tmp2 = M * abs(ddx(QDFR,V(`GEFF)));
+      Cgsex = Cgsi + (CGSO * M * WeffNF) + Cgsov + tmp1;
+      Cgdex = Cgdi + (CGDO * M * WeffNF) + Cgdov + tmp2;
+    end
     Cgbex = Cgbi + CGBO * M * 2.0 * Leff * NF ;
     Ctotex = Cgsex + Cgbex + Cgdex;
     ////Intrnsic Gain ///////////////////////


### PR DESCRIPTION
The use of "tmp1" and "tmp2" variables in multiple contexts in EKV3 (in expressions destined for contributions and as temporaries holding ddx()) confuses Xyce/ADMS into thinking it needs to generate code for second derivatives in every expression involving tmp1 or tmp2.

Wrapping the single instance of tmp1 and tmp2 having ddx stored into them (which are then immediately used in a later computation and then discarded) inside a begin/end block and making those tmp1 and tmp2 variables block local completely fixes the misunderstanding, and Xyce/ADMS no longer generates second derivative code anywhere.

This simple fix should be used if (when?) Xyce decides to import the open source version of EKV 3.02 into Xyce, if that happens before Xyce/ADMS is replaced by something good.  Without this fix, Xyce/ADMS generates a huge amount of completely unnecessary second derivatives.

See also Xyce/Xyce/issues/104